### PR TITLE
Change property name to prevent YUICompressor throwing a hissy fit

### DIFF
--- a/components/js/external/d3-parsets/d3.parsets.js
+++ b/components/js/external/d3-parsets/d3.parsets.js
@@ -500,7 +500,7 @@
         d.categories.forEach(function(c) {
           c.x = x;
           c.dx = c.count / total * (width - spacing);
-          c.in = {dx: 0};
+          c.dir_in = {dx: 0};
           c.out = {dx: 0};
           x += c.dx + p;
         });
@@ -523,9 +523,9 @@
           var child = node.children[k];
           child.path = d.path + "\0" + k;
           var target = child.target || {node: c, dimension: dimension};
-          target.x = c.in.dx;
+          target.x = c.dir_in.dx;
           target.dx = child.count / total * (width - spacing);
-          c.in.dx += target.dx;
+          c.dir_in.dx += target.dx;
           var source = child.source || {node: p, dimension: dimensions[depth - 1]};
           source.x = p.out.dx;
           source.dx = target.dx;


### PR DESCRIPTION
Turns out YUICompressor doesn't like the word `in` used for property names in objects, [much like our run in with `delete`](https://github.com/GigaOM/gigaom/issues/4491) as a property name.

See: https://github.com/GigaOM/gigaom/issues/4784
